### PR TITLE
fix: restore support for Bazel 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,26 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        subdir: [base, kwargs, doxyfile, latex, nested, custom, awesome, substitutions]
+        bazel: [7.0.0, 8.0.0]
+        subdir:
+          [
+            base,
+            kwargs,
+            doxyfile,
+            latex,
+            nested,
+            custom,
+            awesome,
+            substitutions,
+          ]
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
+      - name: Create .bazelversion file
+        working-directory: examples
+        run: echo "${{ matrix.bazel }}" > .bazelversion
+        shell: bash
       - name: Build ${{ matrix.subdir }}
         run: bazel build //${{ matrix.subdir }}:doxygen
         working-directory: examples
@@ -35,7 +50,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        subdir: [base, kwargs, doxyfile, latex, nested, custom, awesome, substitutions]
+        subdir:
+          [
+            base,
+            kwargs,
+            doxyfile,
+            latex,
+            nested,
+            custom,
+            awesome,
+            substitutions,
+          ]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -66,10 +91,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        bazel: [7.0.0, 8.0.0]
         subdir: [base]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Create .bazelversion file
+        working-directory: examples
+        run: echo "${{ matrix.bazel }}" > .bazelversion
+        shell: bash
       - name: Install doxygen
         uses: ssciwr/doxygen-install@v1
       - name: Enable use of windows doxygen by decommenting the module extension line
@@ -115,10 +145,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        bazel: [7.0.0, 8.0.0]
         subdir: [base]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Create .bazelversion file
+        working-directory: examples
+        run: echo "${{ matrix.bazel }}" > .bazelversion
+        shell: bash
       - name: Install doxygen
         uses: ssciwr/doxygen-install@v1
         with:
@@ -177,11 +212,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        bazel: [7.0.0, 8.0.0]
         subdir: [root, submodule1, submodule2]
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
+      - name: Create .bazelversion file
+        working-directory: examples
+        run: echo "${{ matrix.bazel }}" > .bazelversion
+        shell: bash
       - name: Build submodules/${{ matrix.subdir }}
         run: bazel build //:doxygen
         working-directory: examples/submodules/${{ matrix.subdir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
             awesome,
             substitutions,
           ]
+        exclude:
+          # In substitution example we use `string_keyed_label_dict`, which is not supported in bazel 7.0.0
+          - bazel: 7.0.0
+            subdir: substitutions
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fix
 
-- Remove dependency on `@bazel_tools//tools/build_defs/repo` to support Bazel 7.0.0 [#22](https://github.com/TendTo/rules_doxygen/issues/22)
+- Remove dependency on `@bazel_tools//tools/build_defs/repo` to support Bazel 7.0.0 [#22](https://github.com/TendTo/rules_doxygen/issues/22) (thanks to @filmil)
 - Remove unnecessary `get_auth`
 
 ### Changed
 
-- Updated documentation and added example with the output substitution
+- Made documentation clearer
 
 ## [2.2.1]
 
@@ -88,7 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for system-wide doxygen installation. This allows the rule to run on mac os, but loses hermeticity. Can be enabled by using doxygen version `0.0.0`.
-- Testes for the new feature in the CI pipeline
+- Tests for the new feature in the CI pipeline
 - Local repository rule for doxygen
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.2.2]
 
+### Added
+
+- CI tests for both Bazel 7 and 8
+
 ### Fix
 
 - Remove dependency on `@bazel_tools//tools/build_defs/repo` to support Bazel 7.0.0 [#22](https://github.com/TendTo/rules_doxygen/issues/22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2]
+
+### Fix
+
+- Remove dependency on `@bazel_tools//tools/build_defs/repo` to support Bazel 7.0.0 [#22](https://github.com/TendTo/rules_doxygen/issues/22)
+- Remove unnecessary `get_auth`
+
+### Changed
+
+- Updated documentation and added example with the output substitution
+
 ## [2.2.1]
 
 ### Fix

--- a/docs/extensions_doc.md
+++ b/docs/extensions_doc.md
@@ -2,6 +2,50 @@
 
 Repository rule for downloading the correct version of doxygen using module extensions.
 
+<a id="get_default_canonical_id"></a>
+
+## get_default_canonical_id
+
+<pre>
+load("@rules_doxygen//:extensions.bzl", "get_default_canonical_id")
+
+get_default_canonical_id(<a href="#get_default_canonical_id-repository_ctx">repository_ctx</a>, <a href="#get_default_canonical_id-urls">urls</a>)
+</pre>
+
+Returns the default canonical id to use for downloads.
+
+Copied from [@bazel_tools//tools/build_defs/repo:cache.bzl](https://github.com/bazelbuild/bazel/blob/dbb05116a07429ec3524bcf7252cedbb11269bea/tools/build_defs/repo/cache.bzl)
+to avoid a dependency on the whole `@bazel_tools` package, since its visibility changed from private to public between Bazel 7.0.0 and 8.0.0.
+
+Returns `""` (empty string) when Bazel is run with
+`--repo_env=BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID=0`.
+
+e.g.
+```python
+load("@bazel_tools//tools/build_defs/repo:cache.bzl", "get_default_canonical_id")
+# ...
+    repository_ctx.download_and_extract(
+        url = urls,
+        integrity = integrity
+        canonical_id = get_default_canonical_id(repository_ctx, urls),
+    ),
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="get_default_canonical_id-repository_ctx"></a>repository_ctx |  The repository context of the repository rule calling this utility function.   |  none |
+| <a id="get_default_canonical_id-urls"></a>urls |  A list of URLs matching what is passed to `repository_ctx.download` and `repository_ctx.download_and_extract`.   |  none |
+
+**RETURNS**
+
+The canonical ID to use for the download, or an empty string if
+  `BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID` is set to `0`.
+
+
 <a id="doxygen_repository"></a>
 
 ## doxygen_repository
@@ -75,7 +119,7 @@ doxygen_repository(
 <pre>
 doxygen_extension = use_extension("@rules_doxygen//:extensions.bzl", "doxygen_extension")
 doxygen_extension.configuration(<a href="#doxygen_extension.configuration-executable">executable</a>, <a href="#doxygen_extension.configuration-platform">platform</a>, <a href="#doxygen_extension.configuration-sha256">sha256</a>, <a href="#doxygen_extension.configuration-version">version</a>)
-doxygen_extension.repository()
+doxygen_extension.repository(<a href="#doxygen_extension.repository-name">name</a>)
 </pre>
 
 Module extension for declaring the doxygen configurations to use.
@@ -84,7 +128,7 @@ The resulting repository will have the following targets:
 - `@doxygen//:doxygen.bzl`, containing the doxygen macro used to generate the documentation.
 - `@doxygen//:Doxyfile.template`, default Doxyfile template used to generate the Doxyfile.
 
-The extension will create a default configuration for all platforms with the version `1.12.0` of Doxygen.
+The extension will create a default configuration for all platforms with the version `1.13.2` of Doxygen.
 You can override this value with a custom one for each supported platform, i.e. _windows_, _mac_, _mac-arm_, _linux_ and _linux-arm_.
 
 ```bzl
@@ -230,8 +274,8 @@ use_repo(doxygen_extension, "doxygen")
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="doxygen_extension.configuration-executable"></a>executable |  The doxygen executable to use. If set, no download will take place and the provided doxygen executable will be used. Mutually exclusive with `version`.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="doxygen_extension.configuration-platform"></a>platform |  The target platform for the doxygen binary. Available options are (windows, mac, mac-arm, linux, linux-arm). If not specified, it will select the platform it is currently running on.   | String | optional |  `""`  |
+| <a id="doxygen_extension.configuration-executable"></a>executable |  Target pointing to the doxygen executable to use. If set, no download will take place and the provided doxygen executable will be used. Mutually exclusive with `version`.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="doxygen_extension.configuration-platform"></a>platform |  The platform this configuration applies to. Available options are (windows, mac, mac-arm, linux, linux-arm). If not specified, the configuration will apply to the platform it is currently running on.   | String | optional |  `""`  |
 | <a id="doxygen_extension.configuration-sha256"></a>sha256 |  The sha256 hash of the doxygen archive. If not specified, an all-zero hash will be used.   | String | optional |  `""`  |
 | <a id="doxygen_extension.configuration-version"></a>version |  The version of doxygen to use. If set to `0.0.0`, the doxygen executable will be assumed to be available from the PATH. Mutually exclusive with `executable`.   | String | optional |  `""`  |
 
@@ -243,5 +287,6 @@ use_repo(doxygen_extension, "doxygen")
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="doxygen_extension.repository-name"></a>name |  The name of the repository the extension will create. Useful if you don't use 'rules_doxygen' as a dev_dependency, since it will avoid name collision for module depending on yours. Can only be specified once. Defaults to 'doxygen'.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 
 

--- a/examples/substitutions/README.md
+++ b/examples/substitutions/README.md
@@ -83,6 +83,10 @@ make_var_substitution = rule(
 )
 ```
 
+> [!IMPORTANT]  
+> The `string_keyed_label_dict` attribute is not available in bazel 7.0.0.
+> As an alternative, you can use two lists, one for the keys (strings) and one for the values (labels).
+
 Finally, the substitution rule can be used as a toolchain in the doxygen rule.
 
 All configurations using the make variable syntax will be replaced with the values defined in the make_var_substitution rule.

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -320,11 +320,11 @@ def _doxygen_extension_impl(ctx):
 _doxygen_configuration_tag = tag_class(attrs = {
     "version": attr.string(doc = "The version of doxygen to use. If set to `0.0.0`, the doxygen executable will be assumed to be available from the PATH. Mutually exclusive with `executable`."),
     "sha256": attr.string(doc = "The sha256 hash of the doxygen archive. If not specified, an all-zero hash will be used."),
-    "platform": attr.string(doc = "The target platform for the doxygen binary. Available options are (windows, mac, mac-arm, linux, linux-arm). If not specified, it will select the platform it is currently running on."),
-    "executable": attr.label(doc = "The doxygen executable to use. If set, no download will take place and the provided doxygen executable will be used. Mutually exclusive with `version`."),
+    "platform": attr.string(doc = "The platform this configuration applies to. Available options are (windows, mac, mac-arm, linux, linux-arm). If not specified, the configuration will apply to the platform it is currently running on."),
+    "executable": attr.label(doc = "Target pointing to the doxygen executable to use. If set, no download will take place and the provided doxygen executable will be used. Mutually exclusive with `version`."),
 })
 _doxygen_repository_tag = tag_class(attrs = {
-    "name": attr.string(doc = "The name of the repository the extension will create. Useful if you don't use 'rules_doxygen' as a dev_dependency, since it will avoid name collision for module depending on yours. Must be the same for all configurations. Defaults to 'doxygen'.", mandatory = True),
+    "name": attr.string(doc = "The name of the repository the extension will create. Useful if you don't use 'rules_doxygen' as a dev_dependency, since it will avoid name collision for module depending on yours. Can only be specified once. Defaults to 'doxygen'.", mandatory = True),
 })
 
 doxygen_extension = module_extension(

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -1,7 +1,46 @@
 """Repository rule for downloading the correct version of doxygen using module extensions."""
 
-load("@bazel_tools//tools/build_defs/repo:cache.bzl", "get_default_canonical_id")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "get_auth")
+def get_default_canonical_id(repository_ctx, urls):
+    """Returns the default canonical id to use for downloads.
+
+    Copied from [@bazel_tools//tools/build_defs/repo:cache.bzl](https://github.com/bazelbuild/bazel/blob/dbb05116a07429ec3524bcf7252cedbb11269bea/tools/build_defs/repo/cache.bzl)
+    to avoid a dependency on the whole `@bazel_tools` package, since its visibility changed from private to public between Bazel 7.0.0 and 8.0.0.
+
+    Returns `""` (empty string) when Bazel is run with
+    `--repo_env=BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID=0`.
+
+    e.g.
+    ```python
+    load("@bazel_tools//tools/build_defs/repo:cache.bzl", "get_default_canonical_id")
+    # ...
+        repository_ctx.download_and_extract(
+            url = urls,
+            integrity = integrity
+            canonical_id = get_default_canonical_id(repository_ctx, urls),
+        ),
+    ```
+
+    Args:
+      repository_ctx: The repository context of the repository rule calling this utility
+        function.
+      urls: A list of URLs matching what is passed to `repository_ctx.download` and
+        `repository_ctx.download_and_extract`.
+
+    Returns:
+        The canonical ID to use for the download, or an empty string if
+        `BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID` is set to `0`.
+    """
+    DEFAULT_CANONICAL_ID_ENV = "BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID"
+    if repository_ctx.os.environ.get(DEFAULT_CANONICAL_ID_ENV) == "0":
+        return ""
+
+    # Do not sort URLs to prevent the following scenario:
+    # 1. http_archive with urls = [B, A] created.
+    # 2. Successful fetch from B results in canonical ID "A B".
+    # 3. Order of urls is flipped to [A, B].
+    # 4. Fetch would reuse cache entry for "A B", even though A may be broken (it has never been
+    #    fetched before).
+    return " ".join(urls)
 
 def _get_current_platform(ctx):
     """
@@ -91,7 +130,6 @@ def _doxygen_repository(ctx):
                 sha256 = sha256,
                 type = "zip",
                 canonical_id = get_default_canonical_id(ctx, [url]),
-                auth = get_auth(ctx, [url]),
             )
 
             # Copy the doxygen executable (and dll) to the repository
@@ -107,7 +145,6 @@ def _doxygen_repository(ctx):
                 output = download_output,
                 sha256 = sha256,
                 canonical_id = get_default_canonical_id(ctx, [url]),
-                auth = get_auth(ctx, [url]),
             )
 
             # Mount the dmg file
@@ -128,7 +165,6 @@ def _doxygen_repository(ctx):
                 sha256 = sha256,
                 type = "tar.gz",
                 canonical_id = get_default_canonical_id(ctx, [url]),
-                auth = get_auth(ctx, [url]),
                 stripPrefix = "doxygen-%s" % doxygen_version,
             )
 


### PR DESCRIPTION
- Remove dependency on `@bazel_tools//tools/build_defs/repo` to support Bazel 7.0.0 [ closes #22 ] (thanks to @filmil)
- Remove unnecessary `get_auth`
- Add CI tests for both Bazel 7.0.0 and 8.0.0