### PR TITLE
feat: collect transitive sources

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -17,3 +17,4 @@ bcr_test_module:
         - "//awesome:doxygen"
         - "//kwargs:doxygen"
         - "//substitutions:doxygen"
+        - "//dependencies:doxygen"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
             custom,
             awesome,
             substitutions,
+            dependencies,
           ]
         exclude:
           # In substitution example we use `string_keyed_label_dict`, which is not supported in bazel 7.0.0
@@ -54,17 +55,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        subdir:
-          [
-            base,
-            kwargs,
-            doxyfile,
-            latex,
-            nested,
-            custom,
-            awesome,
-            substitutions,
-          ]
+        subdir: [base]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.3]
+
+### Added
+
+- Support for dependency inclusion in the `doxygen` rule [#24](https://github.com/TendTo/rules_doxygen/pull/24) (thanks to @oxidase)
+
+### Changed
+
+- `srcs` attribute in the `doxygen` macro is now optional, as it defaults to `[]`
+- Updated documentation
+
 ## [2.2.2]
 
 ### Added
@@ -155,4 +166,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [2.2.0]: https://github.com/TendTo/rules_doxygen/compare/2.1.0...2.2.0
 [2.2.1]: https://github.com/TendTo/rules_doxygen/compare/2.2.0...2.2.1
 [2.2.2]: https://github.com/TendTo/rules_doxygen/compare/2.2.1...2.2.2
-[NEXT.VERSION]: https://github.com/TendTo/rules_doxygen/compare/2.2.2...HEAD
+[2.2.3]: https://github.com/TendTo/rules_doxygen/compare/2.2.2...2.2.3
+[NEXT.VERSION]: https://github.com/TendTo/rules_doxygen/compare/2.2.3...HEAD

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ doxygen(
         "*.h",          # Usually includes the source files and the markdown files.
         "*.cpp",
     ]) + ["README.md"],
+    # Additionally, you can use the `deps` attribute to select a target 
+    # and automatically include all of the files in its `srcs`, `hdrs`, and `data` attributes,
+    # along with all of its transitive dependencies.
+    # deps = [":my_cc_target"],
     project_brief = DESCRIPTION,            # Brief description of the project
     project_name = NAME,                    # Name of the project
     generate_html = True,                   # Whether to generate HTML output

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ doxygen(
         "*.h",          # Usually includes the source files and the markdown files.
         "*.cpp",
     ]) + ["README.md"],
-    # Additionally, you can use the `deps` attribute to select a target 
+    # Additionally, you can use the `deps` attribute to select a target
     # and automatically include all of the files in its `srcs`, `hdrs`, and `data` attributes,
     # along with all of its transitive dependencies.
     # deps = [":my_cc_target"],
@@ -176,6 +176,73 @@ They will simply be appended at the end of the file, overriding the default valu
 
 > [!Note]
 > See the [documentation](docs/doxygen_doc.md) for more information or the [examples](examples) directory for examples of how to use the rules.
+
+### Differences between `srcs` and `deps`
+
+The `srcs` and `deps` attributes work differently, and are not interchangeable.
+
+`srcs` is a list of files that will be passed to Doxygen for documentation generation.
+You can use `glob` to include a collection of multiple files.  
+On the other hand, if you indicate a target (e.g., `:my_genrule`), it will include all the files produced by that target.
+More precisely, the files in the DefaultInfo provider the target returns.
+Hence, when the documentation is generated, all rules in the `srcs` attribute **will** be built, and the files they output will be passed to Doxygen.
+
+On the other hand, `deps` is a list of targets whose sources will be included in the documentation generation.
+It will automatically include all the files in the `srcs`, `hdrs`, and `data` attributes of the target, and the same applies to all of its transitive dependencies, recursively.
+Since we are only interested in the source files, the `deps` targets **will not** be built when the documentation is generated.
+
+```bzl
+# My BUILD.bazel file
+load("@doxygen//:doxygen.bzl", "doxygen")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "lib",
+    hdrs = ["add.h", "sub.h"],
+    srcs = ["add.cpp", "sub.cpp"],
+)
+
+cc_library(
+    name = "main",
+    srcs = ["main.cpp"],
+    deps = [":lib"],
+)
+
+
+genrule(
+    name = "section",
+    outs = ["Section.md"],
+    cmd = """
+        echo "# Section " > $@
+        echo "This is some amazing documentation with section!!  " >> $@
+        echo "Incredible." >> $@
+    """,
+)
+
+doxygen(
+    name = "doxygen",
+    project_name = "dependencies",
+
+    # The output of the genrule will be included in the documentation.
+    # The genrule will be executed when the documentation is generated.
+    srcs = [
+        "README.md",  # file
+        ":section",  # genrule
+
+        # WARNING: By adding this, the main target will be built
+        # and only the output file `main.o` will be passed to Doxygen,
+        # which is likely not what you want.
+        # ":main"
+    ],
+
+    # The sources of the main target and its dependencies will be included.
+    # No compilation will be performed, so compile error won't be reported.
+    deps = [":main"],  # cc_library
+
+    # Always starts at the root folder
+    use_mdfile_as_mainpage = "dependencies/README.md",
+)
+```
 
 ## Build
 

--- a/docs/doxygen_doc.md
+++ b/docs/doxygen_doc.md
@@ -2,6 +2,25 @@
 
 Doxygen rule for Bazel.
 
+<a id="TransitiveSourcesInfo"></a>
+
+## TransitiveSourcesInfo
+
+<pre>
+load("@rules_doxygen//doxygen:doxygen.bzl", "TransitiveSourcesInfo")
+
+TransitiveSourcesInfo(<a href="#TransitiveSourcesInfo-srcs">srcs</a>)
+</pre>
+
+A provider to collect source files transitively from the target and its dependencies
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="TransitiveSourcesInfo-srcs"></a>srcs |  depset of source files collected from the target and its dependencies    |
+
+
 <a id="doxygen"></a>
 
 ## doxygen
@@ -9,22 +28,23 @@ Doxygen rule for Bazel.
 <pre>
 load("@doxygen//:doxygen.bzl", "doxygen")
 
-doxygen(<a href="#doxygen-name">name</a>, <a href="#doxygen-srcs">srcs</a>, <a href="#doxygen-dot_executable">dot_executable</a>, <a href="#doxygen-configurations">configurations</a>, <a href="#doxygen-doxyfile_template">doxyfile_template</a>, <a href="#doxygen-doxygen_extra_args">doxygen_extra_args</a>, <a href="#doxygen-outs">outs</a>,
-        <a href="#doxygen-doxyfile_encoding">doxyfile_encoding</a>, <a href="#doxygen-project_name">project_name</a>, <a href="#doxygen-project_number">project_number</a>, <a href="#doxygen-project_brief">project_brief</a>, <a href="#doxygen-project_logo">project_logo</a>, <a href="#doxygen-project_icon">project_icon</a>,
-        <a href="#doxygen-create_subdirs">create_subdirs</a>, <a href="#doxygen-create_subdirs_level">create_subdirs_level</a>, <a href="#doxygen-allow_unicode_names">allow_unicode_names</a>, <a href="#doxygen-output_language">output_language</a>, <a href="#doxygen-brief_member_desc">brief_member_desc</a>,
-        <a href="#doxygen-repeat_brief">repeat_brief</a>, <a href="#doxygen-abbreviate_brief">abbreviate_brief</a>, <a href="#doxygen-always_detailed_sec">always_detailed_sec</a>, <a href="#doxygen-inline_inherited_memb">inline_inherited_memb</a>, <a href="#doxygen-full_path_names">full_path_names</a>,
-        <a href="#doxygen-strip_from_path">strip_from_path</a>, <a href="#doxygen-strip_from_inc_path">strip_from_inc_path</a>, <a href="#doxygen-short_names">short_names</a>, <a href="#doxygen-javadoc_autobrief">javadoc_autobrief</a>, <a href="#doxygen-javadoc_banner">javadoc_banner</a>,
-        <a href="#doxygen-qt_autobrief">qt_autobrief</a>, <a href="#doxygen-multiline_cpp_is_brief">multiline_cpp_is_brief</a>, <a href="#doxygen-python_docstring">python_docstring</a>, <a href="#doxygen-inherit_docs">inherit_docs</a>, <a href="#doxygen-separate_member_pages">separate_member_pages</a>,
-        <a href="#doxygen-tab_size">tab_size</a>, <a href="#doxygen-aliases">aliases</a>, <a href="#doxygen-optimize_output_for_c">optimize_output_for_c</a>, <a href="#doxygen-optimize_output_java">optimize_output_java</a>, <a href="#doxygen-optimize_for_fortran">optimize_for_fortran</a>,
-        <a href="#doxygen-optimize_output_vhdl">optimize_output_vhdl</a>, <a href="#doxygen-optimize_output_slice">optimize_output_slice</a>, <a href="#doxygen-extension_mapping">extension_mapping</a>, <a href="#doxygen-markdown_support">markdown_support</a>,
-        <a href="#doxygen-toc_include_headings">toc_include_headings</a>, <a href="#doxygen-markdown_id_style">markdown_id_style</a>, <a href="#doxygen-autolink_support">autolink_support</a>, <a href="#doxygen-autolink_ignore_words">autolink_ignore_words</a>,
-        <a href="#doxygen-builtin_stl_support">builtin_stl_support</a>, <a href="#doxygen-cpp_cli_support">cpp_cli_support</a>, <a href="#doxygen-sip_support">sip_support</a>, <a href="#doxygen-idl_property_support">idl_property_support</a>, <a href="#doxygen-distribute_group_doc">distribute_group_doc</a>,
-        <a href="#doxygen-group_nested_compounds">group_nested_compounds</a>, <a href="#doxygen-subgrouping">subgrouping</a>, <a href="#doxygen-inline_grouped_classes">inline_grouped_classes</a>, <a href="#doxygen-inline_simple_structs">inline_simple_structs</a>,
-        <a href="#doxygen-typedef_hides_struct">typedef_hides_struct</a>, <a href="#doxygen-lookup_cache_size">lookup_cache_size</a>, <a href="#doxygen-num_proc_threads">num_proc_threads</a>, <a href="#doxygen-timestamp">timestamp</a>, <a href="#doxygen-extract_all">extract_all</a>,
-        <a href="#doxygen-extract_private">extract_private</a>, <a href="#doxygen-extract_priv_virtual">extract_priv_virtual</a>, <a href="#doxygen-extract_package">extract_package</a>, <a href="#doxygen-extract_static">extract_static</a>, <a href="#doxygen-extract_local_classes">extract_local_classes</a>,
-        <a href="#doxygen-extract_local_methods">extract_local_methods</a>, <a href="#doxygen-extract_anon_nspaces">extract_anon_nspaces</a>, <a href="#doxygen-resolve_unnamed_params">resolve_unnamed_params</a>, <a href="#doxygen-hide_undoc_members">hide_undoc_members</a>,
-        <a href="#doxygen-hide_undoc_classes">hide_undoc_classes</a>, <a href="#doxygen-hide_undoc_namespaces">hide_undoc_namespaces</a>, <a href="#doxygen-hide_friend_compounds">hide_friend_compounds</a>, <a href="#doxygen-hide_in_body_docs">hide_in_body_docs</a>,
-        <a href="#doxygen-internal_docs">internal_docs</a>, <a href="#doxygen-case_sense_names">case_sense_names</a>, <a href="#doxygen-hide_scope_names">hide_scope_names</a>, <a href="#doxygen-hide_compound_reference">hide_compound_reference</a>, <a href="#doxygen-show_headerfile">show_headerfile</a>,
+doxygen(<a href="#doxygen-name">name</a>, <a href="#doxygen-srcs">srcs</a>, <a href="#doxygen-deps">deps</a>, <a href="#doxygen-dot_executable">dot_executable</a>, <a href="#doxygen-configurations">configurations</a>, <a href="#doxygen-doxyfile_template">doxyfile_template</a>, <a href="#doxygen-doxygen_extra_args">doxygen_extra_args</a>,
+        <a href="#doxygen-outs">outs</a>, <a href="#doxygen-doxyfile_encoding">doxyfile_encoding</a>, <a href="#doxygen-project_name">project_name</a>, <a href="#doxygen-project_number">project_number</a>, <a href="#doxygen-project_brief">project_brief</a>, <a href="#doxygen-project_logo">project_logo</a>,
+        <a href="#doxygen-project_icon">project_icon</a>, <a href="#doxygen-create_subdirs">create_subdirs</a>, <a href="#doxygen-create_subdirs_level">create_subdirs_level</a>, <a href="#doxygen-allow_unicode_names">allow_unicode_names</a>, <a href="#doxygen-output_language">output_language</a>,
+        <a href="#doxygen-brief_member_desc">brief_member_desc</a>, <a href="#doxygen-repeat_brief">repeat_brief</a>, <a href="#doxygen-abbreviate_brief">abbreviate_brief</a>, <a href="#doxygen-always_detailed_sec">always_detailed_sec</a>, <a href="#doxygen-inline_inherited_memb">inline_inherited_memb</a>,
+        <a href="#doxygen-full_path_names">full_path_names</a>, <a href="#doxygen-strip_from_path">strip_from_path</a>, <a href="#doxygen-strip_from_inc_path">strip_from_inc_path</a>, <a href="#doxygen-short_names">short_names</a>, <a href="#doxygen-javadoc_autobrief">javadoc_autobrief</a>,
+        <a href="#doxygen-javadoc_banner">javadoc_banner</a>, <a href="#doxygen-qt_autobrief">qt_autobrief</a>, <a href="#doxygen-multiline_cpp_is_brief">multiline_cpp_is_brief</a>, <a href="#doxygen-python_docstring">python_docstring</a>, <a href="#doxygen-inherit_docs">inherit_docs</a>,
+        <a href="#doxygen-separate_member_pages">separate_member_pages</a>, <a href="#doxygen-tab_size">tab_size</a>, <a href="#doxygen-aliases">aliases</a>, <a href="#doxygen-optimize_output_for_c">optimize_output_for_c</a>, <a href="#doxygen-optimize_output_java">optimize_output_java</a>,
+        <a href="#doxygen-optimize_for_fortran">optimize_for_fortran</a>, <a href="#doxygen-optimize_output_vhdl">optimize_output_vhdl</a>, <a href="#doxygen-optimize_output_slice">optimize_output_slice</a>, <a href="#doxygen-extension_mapping">extension_mapping</a>,
+        <a href="#doxygen-markdown_support">markdown_support</a>, <a href="#doxygen-toc_include_headings">toc_include_headings</a>, <a href="#doxygen-markdown_id_style">markdown_id_style</a>, <a href="#doxygen-autolink_support">autolink_support</a>,
+        <a href="#doxygen-autolink_ignore_words">autolink_ignore_words</a>, <a href="#doxygen-builtin_stl_support">builtin_stl_support</a>, <a href="#doxygen-cpp_cli_support">cpp_cli_support</a>, <a href="#doxygen-sip_support">sip_support</a>,
+        <a href="#doxygen-idl_property_support">idl_property_support</a>, <a href="#doxygen-distribute_group_doc">distribute_group_doc</a>, <a href="#doxygen-group_nested_compounds">group_nested_compounds</a>, <a href="#doxygen-subgrouping">subgrouping</a>,
+        <a href="#doxygen-inline_grouped_classes">inline_grouped_classes</a>, <a href="#doxygen-inline_simple_structs">inline_simple_structs</a>, <a href="#doxygen-typedef_hides_struct">typedef_hides_struct</a>, <a href="#doxygen-lookup_cache_size">lookup_cache_size</a>,
+        <a href="#doxygen-num_proc_threads">num_proc_threads</a>, <a href="#doxygen-timestamp">timestamp</a>, <a href="#doxygen-extract_all">extract_all</a>, <a href="#doxygen-extract_private">extract_private</a>, <a href="#doxygen-extract_priv_virtual">extract_priv_virtual</a>,
+        <a href="#doxygen-extract_package">extract_package</a>, <a href="#doxygen-extract_static">extract_static</a>, <a href="#doxygen-extract_local_classes">extract_local_classes</a>, <a href="#doxygen-extract_local_methods">extract_local_methods</a>,
+        <a href="#doxygen-extract_anon_nspaces">extract_anon_nspaces</a>, <a href="#doxygen-resolve_unnamed_params">resolve_unnamed_params</a>, <a href="#doxygen-hide_undoc_members">hide_undoc_members</a>, <a href="#doxygen-hide_undoc_classes">hide_undoc_classes</a>,
+        <a href="#doxygen-hide_undoc_namespaces">hide_undoc_namespaces</a>, <a href="#doxygen-hide_friend_compounds">hide_friend_compounds</a>, <a href="#doxygen-hide_in_body_docs">hide_in_body_docs</a>, <a href="#doxygen-internal_docs">internal_docs</a>,
+        <a href="#doxygen-case_sense_names">case_sense_names</a>, <a href="#doxygen-hide_scope_names">hide_scope_names</a>, <a href="#doxygen-hide_compound_reference">hide_compound_reference</a>, <a href="#doxygen-show_headerfile">show_headerfile</a>,
         <a href="#doxygen-show_include_files">show_include_files</a>, <a href="#doxygen-show_grouped_memb_inc">show_grouped_memb_inc</a>, <a href="#doxygen-force_local_includes">force_local_includes</a>, <a href="#doxygen-inline_info">inline_info</a>,
         <a href="#doxygen-sort_member_docs">sort_member_docs</a>, <a href="#doxygen-sort_brief_docs">sort_brief_docs</a>, <a href="#doxygen-sort_members_ctors_1st">sort_members_ctors_1st</a>, <a href="#doxygen-sort_group_names">sort_group_names</a>,
         <a href="#doxygen-sort_by_scope_name">sort_by_scope_name</a>, <a href="#doxygen-strict_proto_matching">strict_proto_matching</a>, <a href="#doxygen-generate_todolist">generate_todolist</a>, <a href="#doxygen-generate_testlist">generate_testlist</a>,
@@ -85,25 +105,40 @@ Depending on the type of the attribute, the macro will convert it to the appropr
 - list: the value of the attribute is a string with the elements separated by spaces and enclosed in double quotes
 - str: the value of the attribute is will be set to the string, unchanged. You may need to provide proper quoting if the value contains spaces
 
+For the complete list of Doxygen configuration options, please refer to the [Doxygen documentation](https://www.doxygen.nl/manual/config.html).
+
 ### Example
 
-```starlark
+```bzl
 # MODULE.bazel file
 bazel_dep(name = "rules_doxygen", dev_dependency = True)
 doxygen_extension = use_extension("@rules_doxygen//:extensions.bzl", "doxygen_extension")
 use_repo(doxygen_extension, "doxygen")
 ```
 
-```starlark
+```bzl
 # BUILD.bazel file
 load("@doxygen//:doxygen.bzl", "doxygen")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "lib",
+    srcs = ["add.cpp", "sub.cpp"],
+    hdrs = ["add.h", "sub.h"],
+)
+
+cc_library(
+    name = "main",
+    srcs = ["main.cpp"],
+    deps = [":lib"],
+)
 
 doxygen(
     name = "doxygen",
     srcs = glob([
-        "*.h",
-        "*.cpp",
+        "*.md",
     ]),
+    deps = [":main"]
     aliases = [
         "licence=@par Licence:^^",
         "verb{1}=@verbatim \\1 @endverbatim",
@@ -121,7 +156,8 @@ doxygen(
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="doxygen-name"></a>name |  A name for the target.   |  none |
-| <a id="doxygen-srcs"></a>srcs |  A list of source files to generate documentation for.   |  none |
+| <a id="doxygen-srcs"></a>srcs |  A list of source files to generate documentation for.   |  `[]` |
+| <a id="doxygen-deps"></a>deps |  A list of dependencies whose source, header and data files, and those or the transitive dependencies, will be included in the documentation.   |  `[]` |
 | <a id="doxygen-dot_executable"></a>dot_executable |  Label of the doxygen executable. Make sure it is also added to the `srcs` of the macro   |  `None` |
 | <a id="doxygen-configurations"></a>configurations |  A list of additional configuration parameters to pass to Doxygen.   |  `None` |
 | <a id="doxygen-doxyfile_template"></a>doxyfile_template |  The template file to use to generate the Doxyfile. The following substitutions are available:<br> - `# {{INPUT}}`: Subpackage directory in the sandbox.<br> - `# {{ADDITIONAL PARAMETERS}}`: Additional parameters given in the `configurations` attribute.<br> - `# {{OUTPUT DIRECTORY}}`: The directory provided in the `outs` attribute.   |  `None` |
@@ -433,5 +469,27 @@ doxygen(
 | <a id="doxygen-mscgen_tool"></a>mscgen_tool |  You can define message sequence charts within Doxygen comments using the \msc command.   |  `None` |
 | <a id="doxygen-mscfile_dirs"></a>mscfile_dirs |  The `mscfile_dirs` tag can be used to specify one or more directories that contain msc files that are included in the documentation (see the \mscfile command).   |  `None` |
 | <a id="doxygen-kwargs"></a>kwargs |  Additional arguments to pass to the rule (e.g. `visibility = ["//visibility:public"], tags = ["manual"]`)   |  none |
+
+
+<a id="collect_files_aspect"></a>
+
+## collect_files_aspect
+
+<pre>
+load("@rules_doxygen//doxygen:doxygen.bzl", "collect_files_aspect")
+
+collect_files_aspect()
+</pre>
+
+When applied to a target, this aspect collects the source files from the target and its dependencies, and makes them available in the TransitiveSourcesInfo provider.
+
+**ASPECT ATTRIBUTES**
+
+
+| Name | Type |
+| :------------- | :------------- |
+| deps| String |
+
+
 
 

--- a/docs/extensions_doc.md
+++ b/docs/extensions_doc.md
@@ -72,7 +72,7 @@ You can further customize the repository by specifying the `doxygen_bzl`, `build
 
 ### Example
 
-```starlark
+```bzl
 # Download the os specific version 1.12.0 of doxygen supporting all the indicated platforms
 doxygen_repository(
     name = "doxygen",
@@ -180,7 +180,7 @@ No download will be performed, and the file indicated by the label will be used 
 
 ### Examples
 
-```starlark
+```bzl
 # MODULE.bazel file
 
 bazel_dep(name = "rules_doxygen", version = "...", dev_dependency = True)
@@ -198,7 +198,7 @@ doxygen_extension.configuration(
 use_repo(doxygen_extension, "doxygen")
 ```
 
-```starlark
+```bzl
 # MODULE.bazel file
 
 bazel_dep(name = "rules_doxygen", version = "...", dev_dependency = True)

--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -168,7 +168,8 @@ def _add_generic_configuration(configurations, name, value):
 
 def doxygen(
         name,
-        srcs,
+        srcs = [],
+        deps = [],
         # Bazel specific attributes
         dot_executable = None,
         configurations = None,
@@ -527,6 +528,7 @@ def doxygen(
     Args:
         name: A name for the target.
         srcs: A list of source files to generate documentation for.
+        deps: A list of dependencies whose source, header and data files, and those or the transitive dependencies, will be included in the documentation.
         dot_executable: Label of the doxygen executable. Make sure it is also added to the `srcs` of the macro
         configurations: A list of additional configuration parameters to pass to Doxygen.
         doxyfile_template: The template file to use to generate the Doxyfile.
@@ -1161,6 +1163,7 @@ def doxygen(
     _doxygen(
         name = name,
         srcs = srcs,
+        deps = deps,
         outs = outs,
         configurations = configurations,
         doxygen_extra_args = doxygen_extra_args,

--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -123,14 +123,14 @@ doxygen(
 """,
     implementation = _doxygen_impl,
     attrs = {
-        "srcs": attr.label_list(allow_files = True, doc = "The source files to generate documentation for. Can include header files, source files, and any other file Doxygen can parse."),
-        "deps": attr.label_list(aspects = [collect_files_aspect], doc = "The dependencies targets whose files in their 'src', 'hdrs' and 'data' attributes will be collected to generate the documentation. Transitive dependencies are also taken into account."),
+        "srcs": attr.label_list(allow_files = True, doc = "List of source files to generate documentation for. Can include any file that Doxygen can parse, as well as targets that return a DefaultInfo provider (usually genrules). Since we are only considering the outputs files and not the sources, these targets **will** be built if necessary."),
+        "deps": attr.label_list(aspects = [collect_files_aspect], doc = "List of dependencies targets whose files present in the 'src', 'hdrs' and 'data' attributes will be collected to generate the documentation. Transitive dependencies are also taken into account. Since we are only considering the source files and not the outputs, these targets **will not** be built"),
         "configurations": attr.string_list(doc = "Additional configuration parameters to append to the Doxyfile. For example, to set the project name, use `PROJECT_NAME = example`."),
-        "outs": attr.string_list(default = ["html"], allow_empty = False, doc = """The output folders to keep. If only the html outputs is of interest, the default value will do. Otherwise, a list of folders to keep is expected (e.g. `["html", "latex"]`)."""),
+        "outs": attr.string_list(default = ["html"], allow_empty = False, doc = """Output folders to keep. If only the html outputs is of interest, the default value will do. Otherwise, a list of folders to keep is expected (e.g. `["html", "latex"]`)."""),
         "doxyfile_template": attr.label(
             allow_single_file = True,
             default = Label(":Doxyfile.template"),
-            doc = """The template file to use to generate the Doxyfile. You can provide your own or use the default one.
+            doc = """Template file to use to generate the Doxyfile. You can provide your own or use the default one.
 The following substitutions are available:
 - `# {{INPUT}}`: Subpackage directory in the sandbox.
 - `# {{DOT_PATH}}`: Indicate to doxygen the location of the `dot_executable`
@@ -142,7 +142,7 @@ The following substitutions are available:
             executable = True,
             cfg = "exec",
             allow_single_file = True,
-            doc = "The dot executable to use. Must refer to an executable file.",
+            doc = "dot executable to use. Must refer to an executable file.",
         ),
         "doxygen_extra_args": attr.string_list(default = [], doc = "Extra arguments to pass to the doxygen executable."),
         "_executable": attr.label(
@@ -150,7 +150,7 @@ The following substitutions are available:
             cfg = "exec",
             allow_single_file = True,
             default = Label(":executable"),
-            doc = "The doxygen executable to use. Must refer to an executable file.",
+            doc = "doxygen executable to use. Must refer to an executable file.",
         ),
     },
 )
@@ -539,18 +539,22 @@ def doxygen(
     ```
 
     Args:
-        name: A name for the target.
-        srcs: A list of source files to generate documentation for.
-        deps: A list of dependencies whose source, header and data files, and those or the transitive dependencies, will be included in the documentation.
+        name: Name for the target.
+        srcs: List of source files to generate documentation for.
+            Can include any file that Doxygen can parse, as well as targets that return a DefaultInfo provider (usually genrules).
+            Since we are only considering the outputs files and not the sources, these targets **will** be built if necessary.
+        deps: List of dependencies targets whose files present in the 'src', 'hdrs' and 'data' attributes will be collected to generate the documentation.
+            Transitive dependencies are also taken into account.
+            Since we are only considering the source files and not the outputs, these targets **will not** be built.
         dot_executable: Label of the doxygen executable. Make sure it is also added to the `srcs` of the macro
-        configurations: A list of additional configuration parameters to pass to Doxygen.
+        configurations: List of additional configuration parameters to pass to Doxygen.
         doxyfile_template: The template file to use to generate the Doxyfile.
             The following substitutions are available:<br>
             - `# {{INPUT}}`: Subpackage directory in the sandbox.<br>
             - `# {{ADDITIONAL PARAMETERS}}`: Additional parameters given in the `configurations` attribute.<br>
             - `# {{OUTPUT DIRECTORY}}`: The directory provided in the `outs` attribute.
         doxygen_extra_args: Extra arguments to pass to the doxygen executable.
-        outs: The output folders bazel will keep. If only the html outputs is of interest, the default value will do.
+        outs: Output folders bazel will keep. If only the html outputs is of interest, the default value will do.
              otherwise, a list of folders to keep is expected (e.g. ["html", "latex"]).
              Note that the rule will also generate an output group for each folder in the outs list having the same name.
 

--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -12,6 +12,10 @@ def _expand_make_variables(string, ctx):
             string = string.replace("$(%s)" % variable, value)
     return string
 
+TransitiveSourcesInfo = provider(
+    "A provider to collect transitive source files",
+    fields = {"srcs": "depset of source files collected from the target and its dependencies"},
+)
 
 TransitiveSourcesInfo = provider(fields = ["srcs"])
 
@@ -120,7 +124,7 @@ doxygen(
     implementation = _doxygen_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = True, doc = "The source files to generate documentation for. Can include header files, source files, and any other file Doxygen can parse."),
-        "deps": attr.label_list(aspects = [collect_files_aspect]),
+        "deps": attr.label_list(aspects = [collect_files_aspect], doc = "The dependencies targets whose files in their 'src', 'hdrs' and 'data' attributes will be collected to generate the documentation. Transitive dependencies are also taken into account."),
         "configurations": attr.string_list(doc = "Additional configuration parameters to append to the Doxyfile. For example, to set the project name, use `PROJECT_NAME = example`."),
         "outs": attr.string_list(default = ["html"], allow_empty = False, doc = """The output folders to keep. If only the html outputs is of interest, the default value will do. Otherwise, a list of folders to keep is expected (e.g. `["html", "latex"]`)."""),
         "doxyfile_template": attr.label(
@@ -488,6 +492,8 @@ def doxygen(
     - bool: the value of the attribute is the string "YES" or "NO" respectively
     - list: the value of the attribute is a string with the elements separated by spaces and enclosed in double quotes
     - str: the value of the attribute is will be set to the string, unchanged. You may need to provide proper quoting if the value contains spaces
+
+    For the complete list of Doxygen configuration options, please refer to the [Doxygen documentation](https://www.doxygen.nl/manual/config.html).
 
     ### Example
 

--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -37,7 +37,7 @@ def _collect_files_aspect_impl(_, ctx):
 
     # Collect transitive files from dependencies
     transitive_files = []
-    for dep in ctx.rule.attr.deps:
+    for dep in ctx.rule.attr.deps if hasattr(ctx.rule.attr, "deps") else []:
         if TransitiveSourcesInfo in dep:
             transitive_files.append(dep[TransitiveSourcesInfo].srcs)
 

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -6,6 +6,7 @@ local_path_override(
     path = "../",
 )
 
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "aspect_bazel_lib", version = "2.10.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 

--- a/examples/dependencies/BUILD.bazel
+++ b/examples/dependencies/BUILD.bazel
@@ -28,9 +28,24 @@ cc_library(
     deps = [":lib"],
 )
 
+genrule(
+    name = "section",
+    outs = ["Section.md"],
+    cmd = """
+        echo "# Section " > $@
+        echo "This is some amazing documentation with section!!  " >> $@
+        echo "Incredible." >> $@
+    """,
+)
+
 doxygen(
     name = "doxygen",
+    srcs = [
+        "README.md",  # file
+        ":section",  # genrule
+    ],
     project_brief = "Example project for doxygen",
     project_name = "dependencies",
-    deps = [":main"],
+    use_mdfile_as_mainpage = "dependencies/README.md",
+    deps = [":main"],  # cc_library
 )

--- a/examples/dependencies/BUILD.bazel
+++ b/examples/dependencies/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@doxygen//:doxygen.bzl", "doxygen")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "add",
+    srcs = ["add.cpp"],
+    hdrs = ["add.h"],
+)
+
+cc_library(
+    name = "sub",
+    srcs = ["sub.cpp"],
+    hdrs = ["sub.h"],
+)
+
+cc_library(
+    name = "lib",
+    hdrs = ["lib.h"],
+    deps = [
+        ":add",
+        ":sub",
+    ],
+)
+
+cc_library(
+    name = "main",
+    srcs = ["main.cpp"],
+    deps = [":lib"],
+)
+
+doxygen(
+    name = "doxygen",
+    project_brief = "Example project for doxygen",
+    project_name = "dependencies",
+    deps = [":main"],
+)

--- a/examples/dependencies/README.md
+++ b/examples/dependencies/README.md
@@ -1,0 +1,66 @@
+# Dependencies example
+
+In this example, instead of specifying the files to be included in the Doxygen documentation using the `srcs` attribute with a glob, we use the `deps` attribute.
+This allows us to select a target and immediately include all of the files in its `srcs`, `hdrs`, and `data` attributes, along with all of its transitive dependencies.
+
+```bash
+bazel build //dependencies:doxygen
+```
+
+## Showcase
+
+In a very common scenario, imagine working on a C++ project with the following build file:
+
+```bazel
+# BUILD.bazel
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "add",
+    srcs = ["add.cpp"],
+    hdrs = ["add.h"],
+)
+
+cc_library(
+    name = "sub",
+    srcs = ["sub.cpp"],
+    hdrs = ["sub.h"],
+)
+
+cc_library(
+    name = "lib",
+    hdrs = ["lib.h"],
+    deps = [
+        ":add",
+        ":sub",
+    ],
+)
+
+cc_library(
+    name = "main",
+    srcs = ["main.cpp"],
+    deps = [":lib"],
+)
+```
+
+The graph of dependencies looks like this:
+
+```mermaid
+graph TD;
+    A[main.cpp] --> B[lib.h];
+    B --> C[add.h<br>add.cpp];
+    B --> D[sub.h<br>sub.cpp];
+```
+
+If we want to include all of the files in the documentation, we can use the `deps` attribute to collect the `main` target's files and those of its transitive dependencies, like this:
+
+```bazel
+# BUILD.bazel
+load("@doxygen//:doxygen.bzl", "doxygen")
+
+doxygen(
+    name = "doxygen",
+    deps = [":main"],
+    doxygen_config = ":Doxyfile",
+)
+```

--- a/examples/dependencies/README.md
+++ b/examples/dependencies/README.md
@@ -11,7 +11,7 @@ bazel build //dependencies:doxygen
 
 In a very common scenario, imagine working on a C++ project with the following build file:
 
-```bazel
+```bzl
 # BUILD.bazel
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
@@ -54,7 +54,7 @@ graph TD;
 
 If we want to include all of the files in the documentation, we can use the `deps` attribute to collect the `main` target's files and those of its transitive dependencies, like this:
 
-```bazel
+```bzl
 # BUILD.bazel
 load("@doxygen//:doxygen.bzl", "doxygen")
 

--- a/examples/dependencies/add.cpp
+++ b/examples/dependencies/add.cpp
@@ -1,0 +1,13 @@
+/**
+ * @file add.cpp
+ * @author Ernesto Casablanca (casablancaernesto@gmail.com)
+ * @copyright 2024
+ */
+
+#include "add.h"
+
+namespace lib {
+
+int add(int a, int b) { return a + b; }
+
+}

--- a/examples/dependencies/add.h
+++ b/examples/dependencies/add.h
@@ -1,0 +1,22 @@
+/**
+ * @file add.h
+ * @author Ernesto Casablanca (casablancaernesto@gmail.com)
+ * @copyright 2024
+ */
+#pragma once
+
+namespace lib {
+
+/**
+ * @brief Add two integers
+ *
+ * Who knows what the result will be?
+ * @note This function is very complex. Use it with caution.
+ * @warning The result can be greater than the maximum value that can be stored!
+ * @param a First integer
+ * @param b Second integer
+ * @return Sum of a and b
+ */
+int add(int a, int b);
+
+}  // namespace lib

--- a/examples/dependencies/lib.h
+++ b/examples/dependencies/lib.h
@@ -1,0 +1,16 @@
+/**
+ * @file lib.h
+ * @author Ernesto Casablanca (casablancaernesto@gmail.com)
+ * @copyright 2024
+ */
+#pragma once
+
+#include "add.h"
+#include "sub.h"
+
+/**
+ * @namespace lib
+ * An amazing library providing a lot of functions to do math operations.
+ * @note This library is very complex. Use it with caution.
+ */
+namespace lib {}  // namespace lib

--- a/examples/dependencies/main.cpp
+++ b/examples/dependencies/main.cpp
@@ -1,0 +1,17 @@
+/**
+ * @file lib.cpp
+ * @author Ernesto Casablanca (casablancaernesto@gmail.com)
+ * @copyright 2024
+ */
+
+#include <iostream>
+
+#include "lib.h"
+
+int main(int, char*[]) {
+  int a = 5;
+  int b = 10;
+  std::cout << "a + b: " << lib::add(a, b) << std::endl;
+  std::cout << "a - b: " << lib::sub(a, b) << std::endl;
+  return 0;
+}

--- a/examples/dependencies/sub.cpp
+++ b/examples/dependencies/sub.cpp
@@ -1,0 +1,13 @@
+/**
+ * @file sub.cpp
+ * @author Ernesto Casablanca (casablancaernesto@gmail.com)
+ * @copyright 2024
+ */
+
+#include "sub.h"
+
+namespace lib {
+
+int sub(int a, int b) { return a - b; }
+
+}  // namespace lib

--- a/examples/dependencies/sub.h
+++ b/examples/dependencies/sub.h
@@ -1,0 +1,22 @@
+/**
+ * @file sub.h
+ * @author Ernesto Casablanca (casablancaernesto@gmail.com)
+ * @copyright 2024
+ */
+#pragma once
+
+namespace lib {
+
+/**
+ * @brief Substract two integers
+ *
+ * Who knows what the result will be?
+ * @note This function is very complex. Use it with caution.
+ * @warning The result can be greater than the maximum value that can be stored!
+ * @param a First integer
+ * @param b Second integer
+ * @return Subtraction of a and b
+ */
+int sub(int a, int b);
+
+}  // namespace lib

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -192,7 +192,7 @@ You can further customize the repository by specifying the `doxygen_bzl`, `build
 
 ### Example
 
-```starlark
+```bzl
 # Download the os specific version 1.12.0 of doxygen supporting all the indicated platforms
 doxygen_repository(
     name = "doxygen",
@@ -389,7 +389,7 @@ No download will be performed, and the file indicated by the label will be used 
 
 ### Examples
 
-```starlark
+```bzl
 # MODULE.bazel file
 
 bazel_dep(name = "rules_doxygen", version = "...", dev_dependency = True)
@@ -407,7 +407,7 @@ doxygen_extension.configuration(
 use_repo(doxygen_extension, "doxygen")
 ```
 
-```starlark
+```bzl
 # MODULE.bazel file
 
 bazel_dep(name = "rules_doxygen", version = "...", dev_dependency = True)


### PR DESCRIPTION
Would be nice to have a possibility to include transitive sources of `deps` attribute to Doygen input files